### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ attrs==19.3.0
 certifi==2020.6.20
 cffi==1.14.1
 chardet==3.0.4
-cryptg==0.2.post1
+cryptg==0.2.post2
 gunicorn==20.0.4
 hachoir==3.1.1
 idna==2.10


### PR DESCRIPTION
Better Remove Version From Cryptg sometimes terminal phows requirement failed to install or it might be due outdated commit