### PR TITLE
fix: variable be overridden by non-existent env

### DIFF
--- a/tortoolkit/core/varholdern.py
+++ b/tortoolkit/core/varholdern.py
@@ -57,14 +57,12 @@ class VarHolder:
         elif variable in INTS:
             val =  int(envval) if envval is not None else val
         elif variable in BOOLS:
-            if envval:
+            if envval is not None:
                 if not isinstance(val, bool):
                     if "true" in envval.lower():
                         val = True
                     else:
                         val = False
-            else:
-                val = None
         else:
             val =  envval if envval is not None else val
 


### PR DESCRIPTION
When a Boolean environment variable does not exist, the variable value is set to None instead of maintaining the original constant value, which should be wrong.
For example, if LEECH_ENABLED is set to True in ExecVarsSample.py, but the environment variable is not defined, a strange warning will eventually be output: ERROR MainThread tortoolkit.core.varholdern The variable was not found in either the constants, environment or database. Variable is :- LEECH_ENABLED